### PR TITLE
support p8s metrics from stdin

### DIFF
--- a/p8s_to_openfalcon.py
+++ b/p8s_to_openfalcon.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 from __future__ import print_function
-import os
 import re
 import sys
-import subprocess
 import time
 import json
 import argparse
@@ -146,12 +144,8 @@ def read_metric_source(url):
         request.add_header('User-Agent', 'JuiceFS')
         response = urlopen(request, timeout=5)
         return (l.decode('utf8').rstrip() for l in response.readlines())
-    elif url.endswith('meta.py'): # meta.py --metric
-        cmd = os.path.abspath(url)
-        args = [cmd, '--no-update', '--metric']
-        proc = subprocess.Popen(args, stdout=subprocess.PIPE)
-        output = proc.communicate()[0].strip()
-        return (l.decode('utf8').rstrip() for l in output.split('\n'))
+    elif url == '-': # read from stdin
+        return (l.decode('utf8').rstrip() for l in sys.stdin.readlines())
     else:
         raise ValueError('Unsupported url format')
 


### PR DESCRIPTION
1. 支持通过通过标准输入读取 p8s 格式 metric 进行转换
2. 修复了 endpoint 参数的问题：open-falcon 的 metric 中的 endpoint 应该为命令行参数传的 `--endpoint` 参数的值， push 数据应该是用 `--falcon_push_api` 指定的 URL，但是脚本中将 metric 的 endpoint 硬编码成 `test`，用命令行的 `--endpoint` 当做 push 数据的 URL 参数